### PR TITLE
Rename cs_VERSION to controlfilter_VERSION.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ CFLAGS ?= $(OPTIMIZATIONS) -Wall
 STRIP?=strip
 STRIPFLAGS?=-s
 
-cs_VERSION?=$(shell git describe --tags HEAD 2>/dev/null | sed 's/-g.*$$//;s/^v//' || echo "LV2")
+controlfilter_VERSION?=$(shell git describe --tags HEAD 2>/dev/null | sed 's/-g.*$$//;s/^v//' || echo "LV2")
 ###############################################################################
 
 LV2DIR ?= $(PREFIX)/lib/lv2
@@ -42,7 +42,7 @@ targets+=$(BUILDDIR)$(LV2NAME)$(LIB_EXT)
 
 ###############################################################################
 # extract versions
-LV2VERSION=$(cs_VERSION)
+LV2VERSION=$(controlfilter_VERSION)
 include git2lv2.mk
 
 ###############################################################################


### PR DESCRIPTION
The name of this variable needs to match the name used for the submodule
in x42-plugins, in order for the rule that generates gitversion.mak to
work correctly. If the name doesn't match, building x42-plugins from a
tarball will result in it trying to figure out the version based on the
Git tag and failing.
